### PR TITLE
Fix for Issue #5: "POST a new message returns a location that returns a 404"

### DIFF
--- a/src/RestService/Resources/ResourceLocation.cs
+++ b/src/RestService/Resources/ResourceLocation.cs
@@ -72,7 +72,7 @@ namespace TellagoStudios.Hermes.RestService.Resources
 
         public static Uri OfMessageByTopic(Identity topicId, Identity messageId)
         {
-            return CreateUri( "/" + Constants.Routes.Messages + "/" + messageId + "/topic/" + topicId);
+            return CreateUri( "/" + Constants.Routes.Message + "/" + messageId + "/topic/" + topicId);
         }
 
         public static string LinkToMessage(Identity topicId, Identity messageId)


### PR DESCRIPTION
Currently, your feed returns urls for each message similar to the following example:
http://localhost:6156/messages/4e15d16717b6c41fe4c45e72/topic/4e15d12f17b6c41fe4c45e6b

However, the RestClient does not recognize the format "/<strong>messages</strong>/{messageId}/topic/{topicId}". This pull request changes the rendered urls to use <strong>message</strong> instead.
