### PR TITLE
Fix for MongoDB query when specifying a limit

### DIFF
--- a/src/DataAccess.MongoDB/Queries/MessageKeysByTopic.cs
+++ b/src/DataAccess.MongoDB/Queries/MessageKeysByTopic.cs
@@ -21,7 +21,7 @@ namespace TellagoStudios.Hermes.DataAccess.MongoDB.Queries
             var cursor = col.Find(query);
 
             if (skip.HasValue) cursor.SetSkip(skip.Value);
-            if (limit.HasValue) cursor.SetSkip(limit.Value);
+            if (limit.HasValue) cursor.SetLimit(limit.Value);
 
             return cursor.Select(msg => new MessageKey
                 {

--- a/src/DataAccess.MongoDB/Queries/TopicsByGroup.cs
+++ b/src/DataAccess.MongoDB/Queries/TopicsByGroup.cs
@@ -28,7 +28,7 @@ namespace TellagoStudios.Hermes.DataAccess.MongoDB.Queries
         {
             var cursor = topicsCollection.Find(QueryGetByGroup(groupId));
             if (skip.HasValue) cursor.SetSkip(skip.Value);
-            if (limit.HasValue) cursor.SetSkip(limit.Value);
+            if (limit.HasValue) cursor.SetLimit(limit.Value);
             return cursor;
         }
 
@@ -38,7 +38,7 @@ namespace TellagoStudios.Hermes.DataAccess.MongoDB.Queries
             cursor.SetFields("_id");
 
             if (skip.HasValue) cursor.SetSkip(skip.Value);
-            if (limit.HasValue) cursor.SetSkip(limit.Value);
+            if (limit.HasValue) cursor.SetLimit(limit.Value);
 
             return cursor.Select(doc => doc.Id.Value);
         }


### PR DESCRIPTION
When I was trying to get messages for a topic by requesting "/messages/topic/{id}?last={last}&skip={skip}&limit={limit}", I noticed issues when I tried to specify a limit. As it turns out the problem was a result of database query doing a cursor.<strong>SetSkip</strong>(limit.Value) instead of cursor.<strong>SetLimit</strong>(limit.Value). After making the changes in this pull request, the limit argument worked as expected.
